### PR TITLE
Increase maximum users to 32

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -32,7 +32,7 @@
     <bool name="config_enableMultiUserUI">true</bool>
 
     <!--  Maximum number of supported users -->
-    <integer name="config_multiuserMaximumUsers">16</integer>
+    <integer name="config_multiuserMaximumUsers">32</integer>
 
     <!-- Boolean indicating whether the wifi chipset has dual frequency band support -->
     <bool translatable="false" name="config_wifi_dual_band_support">true</bool>


### PR DESCRIPTION
Since there are 64 Weaver slots, the number of users can be safely raised, as of this issue tracker post: https://github.com/GrapheneOS/os-issue-tracker/issues/1331