### PR TITLE
Revert "Use inline carrier extraction"

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -58,8 +58,7 @@ PRODUCT_SOONG_NAMESPACES += \
 	vendor/google/interfaces \
 	vendor/google_devices/common/proprietary/confirmatioui_hal \
 	vendor/google_nos/host/android \
-	vendor/google_nos/test/system-test-harness \
-	vendor/carriersettings-extractor
+	vendor/google_nos/test/system-test-harness
 
 LOCAL_KERNEL := $(TARGET_KERNEL_DIR)/Image.lz4
 
@@ -1187,7 +1186,3 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Call deleteAllKeys if vold detects a factory reset
 PRODUCT_VENDOR_PROPERTIES += ro.crypto.metadata_init_delete_all_keys.enabled=true
-
-PRODUCT_PACKAGES += \
-    extracted-carrierconfig \
-    extracted-apns


### PR DESCRIPTION
This reverts commit 871ff0044c548e7060007e3ea4842b50bf4b87ea.