### PR TITLE
use the Natural display color mode by default

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -684,7 +684,7 @@ PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.surface_flinger.protected_contents=true
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.surface_flinger.display_update_imminent_timeout_ms=50
 
 PRODUCT_PROPERTY_OVERRIDES += \
-	persist.sys.sf.native_mode=2
+	persist.sys.sf.color_saturation=1.0
 PRODUCT_COPY_FILES += \
 	device/google/gs101/display/display_colordata_cal0.pb:$(TARGET_COPY_OUT_VENDOR)/etc/display_colordata_cal0.pb
 


### PR DESCRIPTION
Part of a changelist:
https://github.com/GrapheneOS/device_google_gs201/pull/31
https://github.com/GrapheneOS/device_google_zuma/pull/22
https://github.com/GrapheneOS/device_google_zumapro/pull/10

https://github.com/GrapheneOS/adevtool/pull/165