### PR TITLE
update com.google.hardware.pixel.display in compat matrix to version 15

### DIFF
--- a/device_framework_matrix_product.xml
+++ b/device_framework_matrix_product.xml
@@ -78,7 +78,7 @@
     </hal>
     <hal format="aidl" optional="true">
       <name>com.google.hardware.pixel.display</name>
-        <version>13</version>
+        <version>15</version>
         <interface>
             <name>IDisplay</name>
             <instance>default</instance>


### PR DESCRIPTION
unpacked images diff for both oriole and raven contain

```diff
--- oriole-BP1A.250505.005/product/etc/vintf/compatibility_matrix.xml	2008-12-31 16:00:00.000000000 -0800
+++ oriole-BP2A.250605.031.A2/product/etc/vintf/compatibility_matrix.xml	2008-12-31 16:00:00.000000000 -0800
-    <hal format="aidl" optional="true">
+    <hal format="aidl">
         <name>com.google.hardware.pixel.display</name>
-        <version>13</version>
+        <version>15</version>
         <interface>
             <name>IDisplay</name>
             <instance>default</instance>
         </interface>
     </hal>
```

```diff
--- raven-BP1A.250505.005/product/etc/vintf/compatibility_matrix.xml	2008-12-31 16:00:00.000000000 -0800
+++ raven-BP2A.250605.031.A2/product/etc/vintf/compatibility_matrix.xml	2008-12-31 16:00:00.000000000 -0800
-    <hal format="aidl" optional="true">
+    <hal format="aidl">
         <name>com.google.hardware.pixel.display</name>
-        <version>13</version>
+        <version>15</version>
         <interface>
             <name>IDisplay</name>
             <instance>default</instance>
         </interface>
     </hal>
```